### PR TITLE
Feature/tao 4425 display os and browser error details

### DIFF
--- a/controller/OS.php
+++ b/controller/OS.php
@@ -82,8 +82,21 @@ class OS extends \tao_actions_SaSModule
     {
         /** @var RequirementsServiceInterface $requirementsService */
         $requirementsService = $this->getServiceManager()->get(RequirementsServiceInterface::CONFIG_ID);
+
+        $approvedOs = $requirementsService->getApprovedOs();
+        $approvedOsFormatted = [];
+
+        if (! empty($approvedOs)) {
+            forEach($approvedOs as $os) {
+                $osName = $os->getOnePropertyValue(new \core_kernel_classes_Property(OSService::PROPERTY_NAME));
+                $osVersion = $os->getOnePropertyValue(new \core_kernel_classes_Property(OSService::PROPERTY_VERSION));
+                $approvedOsFormatted[$osName->getLabel()][] = $osVersion->__toString();
+            }
+        }
+
         $this->returnJson([
-            'success' => $requirementsService->osComplies()
+            'success' => $requirementsService->osComplies(),
+            'approvedOs' => $approvedOsFormatted
         ]);
     }
 

--- a/controller/OS.php
+++ b/controller/OS.php
@@ -88,8 +88,8 @@ class OS extends \tao_actions_SaSModule
 
         if (! empty($approvedOs)) {
             forEach($approvedOs as $os) {
-                $osName = $os->getOnePropertyValue(new \core_kernel_classes_Property(OSService::PROPERTY_NAME));
-                $osVersion = $os->getOnePropertyValue(new \core_kernel_classes_Property(OSService::PROPERTY_VERSION));
+                $osName = $os->getUniquePropertyValue(new \core_kernel_classes_Property(OSService::PROPERTY_NAME));
+                $osVersion = $os->getUniquePropertyValue(new \core_kernel_classes_Property(OSService::PROPERTY_VERSION));
                 $approvedOsFormatted[$osName->getLabel()][] = $osVersion->__toString();
             }
         }

--- a/controller/WebBrowsers.php
+++ b/controller/WebBrowsers.php
@@ -88,8 +88,8 @@ class WebBrowsers extends \tao_actions_SaSModule
 
         if (! empty($approvedBrowsers)) {
             forEach($approvedBrowsers as $browser) {
-                $browserName = $browser->getOnePropertyValue(new \core_kernel_classes_Property(WebBrowserService::PROPERTY_NAME));
-                $browserVersion = $browser->getOnePropertyValue(new \core_kernel_classes_Property(WebBrowserService::PROPERTY_VERSION));
+                $browserName = $browser->getUniquePropertyValue(new \core_kernel_classes_Property(WebBrowserService::PROPERTY_NAME));
+                $browserVersion = $browser->getUniquePropertyValue(new \core_kernel_classes_Property(WebBrowserService::PROPERTY_VERSION));
                 $approvedBrowsersFormatted[$browserName->getLabel()][] = $browserVersion->__toString();
             }
         }

--- a/controller/WebBrowsers.php
+++ b/controller/WebBrowsers.php
@@ -82,8 +82,20 @@ class WebBrowsers extends \tao_actions_SaSModule
     {
         /** @var RequirementsServiceInterface $requirementsService */
         $requirementsService = $this->getServiceManager()->get(RequirementsServiceInterface::CONFIG_ID);
+
+        $approvedBrowsers = $requirementsService->getApprovedBrowsers();
+        $approvedBrowsersFormatted = [];
+
+        if (! empty($approvedBrowsers)) {
+            forEach($approvedBrowsers as $browser) {
+                $browserName = $browser->getOnePropertyValue(new \core_kernel_classes_Property(WebBrowserService::PROPERTY_NAME));
+                $browserVersion = $browser->getOnePropertyValue(new \core_kernel_classes_Property(WebBrowserService::PROPERTY_VERSION));
+                $approvedBrowsersFormatted[$browserName->getLabel()][] = $browserVersion->__toString();
+            }
+        }
         $this->returnJson([
-            'success' => $requirementsService->browserComplies()
+            'success' => $requirementsService->browserComplies(),
+            'approvedBrowsers' => $approvedBrowsersFormatted
         ]);
     }
 }

--- a/install/RegisterClientDiagTester.php
+++ b/install/RegisterClientDiagTester.php
@@ -38,6 +38,9 @@ class RegisterClientDiagTester extends \common_ext_action_InstallAction
         $config['testers']['browserVersion'] = [
             'tester' => 'taoClientRestrict/diagnosticTools/browser/tester',
         ];
+        $config['testers']['osVersion'] = [
+            'tester' => 'taoClientRestrict/diagnosticTools/os/tester',
+        ];
 
         $extension->setConfig('clientDiag', $config);
 

--- a/manifest.php
+++ b/manifest.php
@@ -18,6 +18,7 @@
  *
  *
  */
+use oat\taoClientRestrict\controller\OS;
 use oat\taoClientRestrict\install\RegisterAuthProvider;
 use oat\taoClientRestrict\controller\Error;
 use oat\taoClientRestrict\scripts\update\Updater;
@@ -43,6 +44,7 @@ return array(
         array('grant', 'http://www.tao.lu/Ontologies/generis.rdf#taoClientRestrictManager', array('ext'=>'taoClientRestrict')),
         array('grant', 'http://www.tao.lu/Ontologies/TAO.rdf#DeliveryRole', array('controller'=>Error::class)),
         array(AccessRule::GRANT, 'http://www.tao.lu/Ontologies/TAO.rdf#BaseUserRole', WebBrowsers::class),
+        array(AccessRule::GRANT, 'http://www.tao.lu/Ontologies/TAO.rdf#BaseUserRole', OS::class),
     ),
     'install' => array(
         'rdf' => array(

--- a/manifest.php
+++ b/manifest.php
@@ -1,23 +1,23 @@
 <?php
-/**  
+/**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
  * of the License (non-upgradable).
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- * 
+ *
  * Copyright (c) 2016 (original work) Open Assessment Technologies SA;
- *               
- * 
- */               
+ *
+ *
+ */
 use oat\taoClientRestrict\install\RegisterAuthProvider;
 use oat\taoClientRestrict\controller\Error;
 use oat\taoClientRestrict\scripts\update\Updater;
@@ -30,12 +30,12 @@ return array(
     'label' => 'Client Restrictions',
     'description' => '',
     'license' => 'GPL-2.0',
-    'version' => '2.2.0',
+    'version' => '3.0.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=9.0.0',
         'taoDelivery' => '>=3.7.0',
-        'taoClientDiagnostic' => '>=1.9.0',
+        'taoClientDiagnostic' => '>=2.5.0',
         'taoBackOffice' => '>=0.8'
     ),
     'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#taoClientRestrictManager',
@@ -60,11 +60,11 @@ return array(
     'update' => Updater::class,
     'routes' => array(
         '/taoClientRestrict' => 'oat\\taoClientRestrict\\controller'
-    ),    
+    ),
     'constants' => array(
         # views directory
         "DIR_VIEWS" => __DIR__.DIRECTORY_SEPARATOR."views".DIRECTORY_SEPARATOR,
-        
+
             #BASE URL (usually the domain root)
             'BASE_URL' => ROOT_URL.'taoClientRestrict/',
     ),

--- a/model/requirements/RequirementsService.php
+++ b/model/requirements/RequirementsService.php
@@ -36,6 +36,9 @@ class RequirementsService extends ConfigurableService implements RequirementsSer
 
     const URI_DELIVERY_COMPLY_ENABLED = 'http://www.tao.lu/Ontologies/TAODelivery.rdf#ComplyEnabled';
 
+    private $approvedOs = [];
+    private $approvedBrowsers = [];
+
     /**
      * Whether client complies to the delivery execution
      * @param string $deliveryId
@@ -66,12 +69,12 @@ class RequirementsService extends ConfigurableService implements RequirementsSer
     }
 
     public function getApprovedBrowsers(\core_kernel_classes_Resource $delivery = null) {
-        if ($delivery !== null) {
-            return $delivery
+        if ($delivery !== null && empty($this->approvedBrowsers)) {
+            $this->approvedBrowsers = $delivery
                 ->getPropertyValuesCollection(new \core_kernel_classes_Property(self::PROPERTY_DELIVERY_APPROVED_BROWSER))
                 ->toArray();
         }
-        return [];
+        return $this->approvedBrowsers;
     }
 
     /**
@@ -93,12 +96,12 @@ class RequirementsService extends ConfigurableService implements RequirementsSer
     }
 
     public function getApprovedOs(\core_kernel_classes_Resource $delivery = null) {
-        if ($delivery !== null) {
-            return $delivery
+        if ($delivery !== null && empty($this->approvedOs)) {
+            $this->approvedOs = $delivery
                 ->getPropertyValuesCollection(new \core_kernel_classes_Property(self::PROPERTY_DELIVERY_APPROVED_OS))
                 ->toArray();
         }
-        return [];
+        return $this->approvedOs;
     }
 
     /**

--- a/model/requirements/RequirementsService.php
+++ b/model/requirements/RequirementsService.php
@@ -85,11 +85,20 @@ class RequirementsService extends ConfigurableService implements RequirementsSer
             $isOSRestricted = $delivery->getOnePropertyValue(new \core_kernel_classes_Property(self::PROPERTY_DELIVERY_RESTRICT_OS_USAGE));
             if (!is_null($isOSRestricted) && self::URI_DELIVERY_COMPLY_ENABLED == $isOSRestricted->getUri()) {
                 //@TODO property caching  - anyway we are operating with complied
-                $OS = $delivery->getPropertyValuesCollection(new \core_kernel_classes_Property(self::PROPERTY_DELIVERY_APPROVED_OS));
-                $isOSApproved = $this->complies($OS->toArray(), OSService::class);
+                $approvedOs = $this->getApprovedOs($delivery);
+                $isOSApproved = $this->complies($approvedOs, OSService::class);
             }
         }
         return $isOSApproved;
+    }
+
+    public function getApprovedOs(\core_kernel_classes_Resource $delivery = null) {
+        if ($delivery !== null) {
+            return $delivery
+                ->getPropertyValuesCollection(new \core_kernel_classes_Property(self::PROPERTY_DELIVERY_APPROVED_OS))
+                ->toArray();
+        }
+        return [];
     }
 
     /**

--- a/model/requirements/RequirementsService.php
+++ b/model/requirements/RequirementsService.php
@@ -70,12 +70,13 @@ class RequirementsService extends ConfigurableService implements RequirementsSer
 
     public function getApprovedBrowsers(\core_kernel_classes_Resource $delivery = null) {
         if ($delivery !== null) {
-            if (empty($this->approvedBrowsers[$delivery->getUri()])) {
-                $this->approvedBrowsers[$delivery->getUri()] = $delivery
+            $deliveryUri = $delivery->getUri();
+            if (empty($this->approvedBrowsers[$deliveryUri])) {
+                $this->approvedBrowsers[$deliveryUri] = $delivery
                     ->getPropertyValuesCollection(new \core_kernel_classes_Property(self::PROPERTY_DELIVERY_APPROVED_BROWSER))
                     ->toArray();
             }
-            return $this->approvedBrowsers[$delivery->getUri()];
+            return $this->approvedBrowsers[$deliveryUri];
         }
         return [];
     }
@@ -100,12 +101,13 @@ class RequirementsService extends ConfigurableService implements RequirementsSer
 
     public function getApprovedOs(\core_kernel_classes_Resource $delivery = null) {
         if ($delivery !== null) {
-            if (empty($this->approvedOs[$delivery->getUri()])) {
-                $this->approvedOs[$delivery->getUri()] = $delivery
+            $deliveryUri = $delivery->getUri();
+            if (empty($this->approvedOs[$deliveryUri])) {
+                $this->approvedOs[$deliveryUri] = $delivery
                     ->getPropertyValuesCollection(new \core_kernel_classes_Property(self::PROPERTY_DELIVERY_APPROVED_OS))
                     ->toArray();
             }
-            return $this->approvedOs[$delivery->getUri()];
+            return $this->approvedOs[$deliveryUri];
         }
         return [];
     }

--- a/model/requirements/RequirementsService.php
+++ b/model/requirements/RequirementsService.php
@@ -35,7 +35,7 @@ class RequirementsService extends ConfigurableService implements RequirementsSer
     const PROPERTY_DELIVERY_RESTRICT_OS_USAGE = 'http://www.tao.lu/Ontologies/TAODelivery.rdf#RestrictOSUsage';
 
     const URI_DELIVERY_COMPLY_ENABLED = 'http://www.tao.lu/Ontologies/TAODelivery.rdf#ComplyEnabled';
-    
+
     /**
      * Whether client complies to the delivery execution
      * @param string $deliveryId
@@ -58,11 +58,20 @@ class RequirementsService extends ConfigurableService implements RequirementsSer
             $isBrowserRestricted = $delivery->getOnePropertyValue(new \core_kernel_classes_Property(self::PROPERTY_DELIVERY_RESTRICT_BROWSER_USAGE));
             if (!is_null($isBrowserRestricted) && self::URI_DELIVERY_COMPLY_ENABLED == $isBrowserRestricted->getUri()) {
                 //@TODO property caching  - anyway we are operating with complied
-                $browsers = $delivery->getPropertyValuesCollection(new \core_kernel_classes_Property(self::PROPERTY_DELIVERY_APPROVED_BROWSER));
-                $isBrowserApproved = $this->complies($browsers->toArray(), WebBrowserService::class);
+                $browsers = $this->getApprovedBrowsers();
+                $isBrowserApproved = $this->complies($browsers, WebBrowserService::class);
             }
         }
         return $isBrowserApproved;
+    }
+
+    public function getApprovedBrowsers(\core_kernel_classes_Resource $delivery = null) {
+        if ($delivery !== null) {
+            return $delivery
+                ->getPropertyValuesCollection(new \core_kernel_classes_Property(self::PROPERTY_DELIVERY_APPROVED_BROWSER))
+                ->toArray();
+        }
+        return [];
     }
 
     /**
@@ -101,7 +110,7 @@ class RequirementsService extends ConfigurableService implements RequirementsSer
             if ($condition->exists() === true) {
                 /** @var \core_kernel_classes_Resource $requiredName */
                 $requiredName = $condition->getOnePropertyValue(new \core_kernel_classes_Property($conditionService::PROPERTY_NAME));
-                
+
                 if ($clientNameResource && !($clientNameResource->equals($requiredName))) {
                     \common_Logger::i("Client rejected. Required name is ${requiredName} but current name is ${clientName}.");
                     continue;

--- a/model/requirements/RequirementsService.php
+++ b/model/requirements/RequirementsService.php
@@ -69,12 +69,15 @@ class RequirementsService extends ConfigurableService implements RequirementsSer
     }
 
     public function getApprovedBrowsers(\core_kernel_classes_Resource $delivery = null) {
-        if ($delivery !== null && empty($this->approvedBrowsers)) {
-            $this->approvedBrowsers = $delivery
-                ->getPropertyValuesCollection(new \core_kernel_classes_Property(self::PROPERTY_DELIVERY_APPROVED_BROWSER))
-                ->toArray();
+        if ($delivery !== null) {
+            if (empty($this->approvedBrowsers[$delivery->getUri()])) {
+                $this->approvedBrowsers[$delivery->getUri()] = $delivery
+                    ->getPropertyValuesCollection(new \core_kernel_classes_Property(self::PROPERTY_DELIVERY_APPROVED_BROWSER))
+                    ->toArray();
+            }
+            return $this->approvedBrowsers[$delivery->getUri()];
         }
-        return $this->approvedBrowsers;
+        return [];
     }
 
     /**
@@ -96,12 +99,15 @@ class RequirementsService extends ConfigurableService implements RequirementsSer
     }
 
     public function getApprovedOs(\core_kernel_classes_Resource $delivery = null) {
-        if ($delivery !== null && empty($this->approvedOs)) {
-            $this->approvedOs = $delivery
-                ->getPropertyValuesCollection(new \core_kernel_classes_Property(self::PROPERTY_DELIVERY_APPROVED_OS))
-                ->toArray();
+        if ($delivery !== null) {
+            if (empty($this->approvedOs[$delivery->getUri()])) {
+                $this->approvedOs[$delivery->getUri()] = $delivery
+                    ->getPropertyValuesCollection(new \core_kernel_classes_Property(self::PROPERTY_DELIVERY_APPROVED_OS))
+                    ->toArray();
+            }
+            return $this->approvedOs[$delivery->getUri()];
         }
-        return $this->approvedOs;
+        return [];
     }
 
     /**

--- a/model/requirements/RequirementsServiceInterface.php
+++ b/model/requirements/RequirementsServiceInterface.php
@@ -43,6 +43,12 @@ interface RequirementsServiceInterface
 
     /**
      * @param \core_kernel_classes_Resource $delivery
+     * @return array
+     */
+    public function getApprovedBrowsers(\core_kernel_classes_Resource $delivery = null);
+
+    /**
+     * @param \core_kernel_classes_Resource $delivery
      * @return boolean
      */
     public function osComplies(\core_kernel_classes_Resource $delivery = null);

--- a/model/requirements/RequirementsServiceInterface.php
+++ b/model/requirements/RequirementsServiceInterface.php
@@ -53,4 +53,10 @@ interface RequirementsServiceInterface
      */
     public function osComplies(\core_kernel_classes_Resource $delivery = null);
 
+    /**
+     * @param \core_kernel_classes_Resource $delivery
+     * @return array
+     */
+    public function getApprovedOs(\core_kernel_classes_Resource $delivery = null);
+
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -29,7 +29,7 @@ use oat\taoClientRestrict\controller\WebBrowsers;
 use oat\taoClientRestrict\controller\OS;
 
 /**
- * 
+ *
  * @author Joel Bout <joel@taotesting.com>
  */
 class Updater extends common_ext_ExtensionUpdater {
@@ -76,6 +76,7 @@ class Updater extends common_ext_ExtensionUpdater {
             $this->setVersion('2.2.0');
         }
 
+        $this->skip('2.2.0', '3.0.0');
     }
 
 }

--- a/views/js/diagnosticTools/browser/tester.js
+++ b/views/js/diagnosticTools/browser/tester.js
@@ -20,11 +20,12 @@
  */
 define([
     'jquery',
+    'lodash',
     'i18n',
     'util/url',
     'taoClientDiagnostic/tools/getconfig'
 
-], function ($, __, url, getConfig) {
+], function ($, _, __, url, getConfig) {
     'use strict';
 
     /**
@@ -35,7 +36,17 @@ define([
     var _defaults = {
         browserVersionAction: 'diagnose',
         browserVersionController: 'WebBrowsers',
-        browserVersionExtension: 'taoClientRestrict',
+        browserVersionExtension: 'taoClientRestrict'
+    };
+
+    /**
+     * Placeholder variables for custom messages
+     * @type {Object}
+     * @private
+     */
+    var _placeHolders = {
+        CURRENT_BROWSER: '%CURRENT_BROWSER%',
+        APPROVED_BROWSERS: '%APPROVED_BROWSERS%'
     };
 
 
@@ -70,7 +81,7 @@ define([
                             feedback: {
                                 message: data.success ? __('Compatible') : __('Not Compatible'),
                                 threshold: 100,
-                                type: data.success ? 'success' : 'error',
+                                type: data.success ? 'success' : 'error'
                             }
                         };
                         var summary = {
@@ -79,9 +90,26 @@ define([
                                 value: data.success ? __('Compatible') : __('Not Compatible')
                             }
                         };
+                        var customMsg = diagnosticTool.getCustomMsg('diagBrowserCheckResult') || '';
+                        var approvedBrowsers = [];
+
+                        if (_.isObject(data.approvedBrowsers)) {
+                            _.forOwn(data.approvedBrowsers, function(versions, browserName) {
+                                if (_.isArray(versions) && versions.length > 0) {
+                                    browserName += ' (' + versions.join(', ') + ')';
+                                }
+                                approvedBrowsers.push(browserName);
+                            });
+                        }
 
                         status.id = 'browser_version';
                         status.title = __('Web browser version');
+
+                        customMsg = customMsg
+                            // .replace(_placeHolders.CURRENT_BROWSER, currentBrowser)
+                            .replace(_placeHolders.APPROVED_BROWSERS, approvedBrowsers.join(', '));
+                        diagnosticTool.addCustomFeedbackMsg(status, customMsg);
+
 
                         done(status, summary, {compatible: data.success});
                     }

--- a/views/js/diagnosticTools/browser/tester.js
+++ b/views/js/diagnosticTools/browser/tester.js
@@ -114,7 +114,6 @@ define([
                                     .replace(_placeHolders.APPROVED_BROWSERS, approvedBrowsers.join(', '));
                                 diagnosticTool.addCustomFeedbackMsg(status, customMsg);
 
-
                                 done(status, summary, {compatible: data.success});
                             }
                         });

--- a/views/js/diagnosticTools/os/tester.js
+++ b/views/js/diagnosticTools/os/tester.js
@@ -107,8 +107,8 @@ define([
                                     });
                                 }
 
-                                status.id = 'browser_version';
-                                status.title = __('Web browser version');
+                                status.id = 'os_version';
+                                status.title = __('Operating system version');
 
                                 customMsg = customMsg
                                     .replace(_placeHolders.CURRENT_OS, currentOs)

--- a/views/js/diagnosticTools/os/tester.js
+++ b/views/js/diagnosticTools/os/tester.js
@@ -35,7 +35,7 @@ define([
     var _defaults = {
         osVersionAction: 'diagnose',
         osVersionController: 'OS',
-        osVersionExtension: 'taoClientRestrict',
+        osVersionExtension: 'taoClientRestrict'
     };
 
 
@@ -70,7 +70,7 @@ define([
                             feedback: {
                                 message: data.success ? __('Compatible') : __('Not Compatible'),
                                 threshold: 100,
-                                type: data.success ? 'success' : 'error',
+                                type: data.success ? 'success' : 'error'
                             }
                         };
                         var summary = {

--- a/views/js/diagnosticTools/os/tester.js
+++ b/views/js/diagnosticTools/os/tester.js
@@ -20,11 +20,13 @@
  */
 define([
     'jquery',
+    'lodash',
     'i18n',
     'util/url',
-    'taoClientDiagnostic/tools/getconfig'
+    'taoClientDiagnostic/tools/getconfig',
+    'taoClientDiagnostic/tools/getPlatformInfo'
 
-], function ($, __, url, getConfig) {
+], function ($, _, __, url, getConfig, getPlatformInfo) {
     'use strict';
 
     /**
@@ -36,6 +38,16 @@ define([
         osVersionAction: 'diagnose',
         osVersionController: 'OS',
         osVersionExtension: 'taoClientRestrict'
+    };
+
+    /**
+     * Placeholder variables for custom messages
+     * @type {Object}
+     * @private
+     */
+    var _placeHolders = {
+        CURRENT_OS: '%CURRENT_OS%',
+        APPROVED_OS: '%APPROVED_OS%'
     };
 
 
@@ -60,32 +72,53 @@ define([
                 var testerUrl = url.route(initConfig.osVersionAction, initConfig.osVersionController, initConfig.osVersionExtension);
 
                 diagnosticTool.changeStatus(__('Checking the os version...'));
-                $.ajax({
-                    url : testerUrl,
-                    success : function(data) {
-                        var percentage = data.success ? 100 : 0;
-                        var status = {
-                            percentage: percentage,
-                            quality: {},
-                            feedback: {
-                                message: data.success ? __('Compatible') : __('Not Compatible'),
-                                threshold: 100,
-                                type: data.success ? 'success' : 'error'
-                            }
-                        };
-                        var summary = {
-                            os: {
-                                message: __('Operating system version'),
-                                value: data.success ? __('Compatible') : __('Not Compatible')
-                            }
-                        };
 
-                        status.id = 'os_version';
-                        status.title = __('Operating system version');
+                getPlatformInfo(window)
+                    .then(function(platformInfo) {
+                        $.ajax({
+                            url : testerUrl,
+                            success : function(data) {
+                                var percentage = data.success ? 100 : 0;
+                                var status = {
+                                    percentage: percentage,
+                                    quality: {},
+                                    feedback: {
+                                        message: data.success ? __('Compatible') : __('Not Compatible'),
+                                        threshold: 100,
+                                        type: data.success ? 'success' : 'error'
+                                    }
+                                };
+                                var summary = {
+                                    os: {
+                                        message: __('Operating system version'),
+                                        value: data.success ? __('Compatible') : __('Not Compatible')
+                                    }
+                                };
+                                var currentOs = platformInfo.os + ' ' + platformInfo.osVersion;
+                                var customMsg = diagnosticTool.getCustomMsg('diagOsCheckResult') || '';
+                                var approvedOs = [];
 
-                        done(status, summary, {compatible: data.success});
-                    }
-                });
+                                if (_.isObject(data.approvedOs)) {
+                                    _.forOwn(data.approvedOs, function (versions, osName) {
+                                        if (_.isArray(versions) && versions.length > 0) {
+                                            osName += ' (' + versions.join(', ') + ')';
+                                        }
+                                        approvedOs.push(osName);
+                                    });
+                                }
+
+                                status.id = 'browser_version';
+                                status.title = __('Web browser version');
+
+                                customMsg = customMsg
+                                    .replace(_placeHolders.CURRENT_OS, currentOs)
+                                    .replace(_placeHolders.APPROVED_OS, approvedOs.join(', '));
+                                diagnosticTool.addCustomFeedbackMsg(status, customMsg);
+
+                                done(status, summary, {compatible: data.success});
+                            }
+                        });
+                    });
             }
         };
     }


### PR DESCRIPTION
companion PRs:
- https://github.com/oat-sa/tao-core/pull/1377
- https://github.com/oat-sa/extension-tao-clientdiag/pull/135
- https://github.com/oat-sa/extension-lti-clientdiag/pull/17/files
- https://github.com/oat-sa/extension-tao-act/pull/585/files

To test:
- create an "Approved browser" class in the backoffice. Put sample data in a way that your test browser is NOT an approved one
- select the green theme via LTI: theme=act_green_theme0
- launch the diagnostic tool via LTI with the parameter: approved_browser=CLASSNAME
- you should see a message stating what is your current browser and what are the allowed browsers.

Repeat the same procedure for OS
