### PR TITLE
Fix/tao 5894 broken diagnostics

### DIFF
--- a/install/RegisterClientDiagTester.php
+++ b/install/RegisterClientDiagTester.php
@@ -36,10 +36,16 @@ class RegisterClientDiagTester extends \common_ext_action_InstallAction
         $config = $extension->getConfig('clientDiag');
 
         $config['testers']['browserVersion'] = [
+            'enabled' => true,
+            'level' => 1,
             'tester' => 'taoClientRestrict/diagnosticTools/browser/tester',
+            'customMsgKey' => 'diagBrowserCheckResult'
         ];
         $config['testers']['osVersion'] = [
+            'enabled' => true,
+            'level' => 1,
             'tester' => 'taoClientRestrict/diagnosticTools/os/tester',
+            'customMsgKey' => 'diagOsCheckResult'
         ];
 
         $extension->setConfig('clientDiag', $config);

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Client Restrictions',
     'description' => '',
     'license' => 'GPL-2.0',
-    'version' => '3.2.1',
+    'version' => '3.3.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=14.3.1',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -77,6 +77,29 @@ class Updater extends common_ext_ExtensionUpdater {
         }
 
         $this->skip('2.2.0', '3.2.1');
+        
+        if ($this->isVersion('3.2.1')) {
+            $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoClientDiagnostic');
+            $config = $extension->getConfig('clientDiag');
+
+            $config['testers']['browserVersion'] = [
+                'enabled' => true,
+                'level' => 1,
+                'tester' => 'taoClientRestrict/diagnosticTools/browser/tester',
+                'customMsgKey' => 'diagBrowserCheckResult'
+            ];
+            
+            $config['testers']['osVersion'] = [
+                'enabled' => true,
+                'level' => 1,
+                'tester' => 'taoClientRestrict/diagnosticTools/os/tester',
+                'customMsgKey' => 'diagOsCheckResult'
+            ];
+
+            $extension->setConfig('clientDiag', $config);
+
+            $this->setVersion('3.3.0');
+        }
     }
 
 }

--- a/views/js/diagnosticTools/browser/tester.js
+++ b/views/js/diagnosticTools/browser/tester.js
@@ -13,19 +13,20 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2016-2017 (original work) Open Assessment Technologies SA ;
  */
 /**
- * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
  */
 define([
     'jquery',
     'lodash',
     'i18n',
     'util/url',
-    'taoClientDiagnostic/tools/getconfig',
+    'taoClientDiagnostic/tools/getConfig',
+    'taoClientDiagnostic/tools/getLabels',
     'taoClientDiagnostic/tools/getPlatformInfo'
-], function ($, _, __, url, getConfig, getPlatformInfo) {
+], function ($, _, __, url, getConfig, getLabels, getPlatformInfo) {
     'use strict';
 
     /**
@@ -34,6 +35,7 @@ define([
      * @private
      */
     var _defaults = {
+        id: 'browser_version',
         browserVersionAction: 'diagnose',
         browserVersionController: 'WebBrowsers',
         browserVersionExtension: 'taoClientRestrict'
@@ -49,18 +51,38 @@ define([
         APPROVED_BROWSERS: '%APPROVED_BROWSERS%'
     };
 
+    /**
+     * List of translated texts per level.
+     * The level is provided through the config as a numeric value, starting from 1.
+     * @type {Object}
+     * @private
+     */
+    var _messages = [
+        // level 1
+        {
+            title: __('Web browser version'),
+            status: __('Checking the browser version...'),
+            success: __('Pass – Your browser is approved'),
+            failure: __('Issue'),
+            compatible: __('Compatible'),
+            notCompatible: __('Not Compatible')
+        }
+    ];
 
     /**
      * Performs a browser support test
      *
-     * @param {Object} [config] - Some optional configs
+     * @param {Object} config - Some optional configs
+     * @param {String} [config.id] - The identifier of the test
      * @param {String} [config.action] - The name of the action to call to get the browser checker
      * @param {String} [config.controller] - The name of the controller to call to get the browser checker
      * @param {String} [config.extension] - The name of the extension containing the controller to call to get the browser checker
+     * @param {String} [config.level] - The intensity level of the test. It will aim which messages list to use.
      * @returns {Object}
      */
-    function browserTester(config, diagnosticTool) {
-        var initConfig = getConfig(config || {}, _defaults);
+    function browserTester(config) {
+        var initConfig = getConfig(config, _defaults);
+        var labels = getLabels(_messages, initConfig.level);
 
         return {
             /**
@@ -69,8 +91,7 @@ define([
              */
             start: function start(done) {
                 var testerUrl = url.route(initConfig.browserVersionAction, initConfig.browserVersionController, initConfig.browserVersionExtension);
-
-                diagnosticTool.changeStatus(__('Checking the browser version...'));
+                var self = this;
 
                 getPlatformInfo(window)
                     .then(function(platformInfo) {
@@ -78,23 +99,9 @@ define([
                             url: testerUrl,
                             success: function (data) {
                                 var percentage = data.success ? 100 : 0;
-                                var status = {
-                                    percentage: percentage,
-                                    quality: {},
-                                    feedback: {
-                                        message: data.success ? __('Pass – Your browser is approved') : __('Issue'),
-                                        threshold: 100,
-                                        type: data.success ? 'success' : 'error'
-                                    }
-                                };
-                                var summary = {
-                                    browser: {
-                                        message: __('Web browser version'),
-                                        value: data.success ? __('Compatible') : __('Not Compatible')
-                                    }
-                                };
+                                var status = self.getFeedback(percentage, data);
+                                var summary = self.getSummary(platformInfo, data);
                                 var currentBrowser = platformInfo.browser + ' ' + platformInfo.browserVersion;
-                                var customMsg = diagnosticTool.getCustomMsg('diagBrowserCheckResult') || '';
                                 var approvedBrowsers = [];
 
                                 if (_.isObject(data.approvedBrowsers)) {
@@ -106,18 +113,62 @@ define([
                                     });
                                 }
 
-                                status.id = 'browser_version';
-                                status.title = __('Web browser version');
-
-                                customMsg = customMsg
-                                    .replace(_placeHolders.CURRENT_BROWSER, currentBrowser)
-                                    .replace(_placeHolders.APPROVED_BROWSERS, approvedBrowsers.join(', '));
-                                diagnosticTool.addCustomFeedbackMsg(status, customMsg);
+                                status.customMsgRenderer = function(customMsg) {
+                                    return (customMsg || '')
+                                        .replace(_placeHolders.CURRENT_BROWSER, currentBrowser)
+                                        .replace(_placeHolders.APPROVED_BROWSERS, approvedBrowsers.join(', '));
+                                };
 
                                 done(status, summary, {compatible: data.success});
                             }
                         });
                     });
+            },
+
+            /**
+             * Gets the labels loaded for the tester
+             * @returns {Object}
+             */
+            get labels() {
+                return labels;
+            },
+
+            /**
+             * Builds the results summary
+             * @param {Object} results
+             * @param {Object} data
+             * @returns {Object}
+             */
+            getSummary: function getSummary(results, data) {
+                return {
+                    browser: {
+                        message: labels.title,
+                        value: data.success ? labels.compatible : labels.notCompatible
+                    }
+                };
+            },
+
+            /**
+             * Gets the feedback status for the provided result value
+             * @param {Number} result
+             * @param {Object} data
+             * @returns {Object}
+             */
+            getFeedback: function getFeedback(result, data) {
+                var status = {
+                    percentage: result,
+                    quality: {},
+                    feedback: {
+                        message: data.success ? labels.success : labels.failure,
+                        threshold: 100,
+                        type: data.success ? 'success' : 'error'
+                    }
+                };
+
+                status.id = initConfig.id;
+                status.title =  labels.title;
+
+                return status;
             }
         };
     }

--- a/views/js/diagnosticTools/os/tester.js
+++ b/views/js/diagnosticTools/os/tester.js
@@ -13,20 +13,20 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2016-2017 (original work) Open Assessment Technologies SA ;
  */
 /**
- * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
  */
 define([
     'jquery',
     'lodash',
     'i18n',
     'util/url',
-    'taoClientDiagnostic/tools/getconfig',
+    'taoClientDiagnostic/tools/getConfig',
+    'taoClientDiagnostic/tools/getLabels',
     'taoClientDiagnostic/tools/getPlatformInfo'
-
-], function ($, _, __, url, getConfig, getPlatformInfo) {
+], function ($, _, __, url, getConfig, getLabels, getPlatformInfo) {
     'use strict';
 
     /**
@@ -35,6 +35,7 @@ define([
      * @private
      */
     var _defaults = {
+        id: 'os_version',
         osVersionAction: 'diagnose',
         osVersionController: 'OS',
         osVersionExtension: 'taoClientRestrict'
@@ -50,53 +51,57 @@ define([
         APPROVED_OS: '%APPROVED_OS%'
     };
 
+    /**
+     * List of translated texts per level.
+     * The level is provided through the config as a numeric value, starting from 1.
+     * @type {Object}
+     * @private
+     */
+    var _messages = [
+        // level 1
+        {
+            title: __('Operating system version'),
+            status: __('Checking the os version...'),
+            success: __('Pass – Your Operating System is approved'),
+            failure: __('Issue'),
+            compatible: __('Compatible'),
+            notCompatible: __('Not Compatible')
+        }
+    ];
 
     /**
-     * Performs a operating system support test
+     * Performs a browser support test
      *
-     * @param {Object} [config] - Some optional configs
-     * @param {String} [config.action] - The name of the action to call to get the os checker
-     * @param {String} [config.controller] - The name of the controller to call to get the os checker
-     * @param {String} [config.extension] - The name of the extension containing the controller to call to get the os checker
+     * @param {Object} config - Some optional configs
+     * @param {String} [config.id] - The identifier of the test
+     * @param {String} [config.action] - The name of the action to call to get the browser checker
+     * @param {String} [config.controller] - The name of the controller to call to get the browser checker
+     * @param {String} [config.extension] - The name of the extension containing the controller to call to get the browser checker
+     * @param {String} [config.level] - The intensity level of the test. It will aim which messages list to use.
      * @returns {Object}
      */
-    function osTester(config, diagnosticTool) {
-        var initConfig = getConfig(config || {}, _defaults);
+    function osTester(config) {
+        var initConfig = getConfig(config, _defaults);
+        var labels = getLabels(_messages, initConfig.level);
 
         return {
             /**
-             * Performs a os support test, then call a function to provide the result
+             * Performs a browser support test, then call a function to provide the result
              * @param {Function} done
              */
             start: function start(done) {
                 var testerUrl = url.route(initConfig.osVersionAction, initConfig.osVersionController, initConfig.osVersionExtension);
-
-                diagnosticTool.changeStatus(__('Checking the os version...'));
+                var self = this;
 
                 getPlatformInfo(window)
                     .then(function(platformInfo) {
                         $.ajax({
-                            url : testerUrl,
-                            success : function(data) {
+                            url: testerUrl,
+                            success: function (data) {
                                 var percentage = data.success ? 100 : 0;
-                                var status = {
-                                    percentage: percentage,
-                                    quality: {},
-                                    feedback: {
-                                        message: data.success ? __('Pass – Your Operating System is approved') : __('Issue'),
-                                        threshold: 100,
-                                        type: data.success ? 'success' : 'error'
-                                    }
-                                };
-                                var summary = {
-                                    os: {
-                                        message: __('Operating system version'),
-                                        value: data.success ? __('Compatible') : __('Not Compatible')
-                                    }
-                                };
+                                var status = self.getFeedback(percentage, data);
+                                var summary = self.getSummary(platformInfo, data);
                                 var currentOs = platformInfo.os + ' ' + platformInfo.osVersion;
-                                var customMsg = diagnosticTool.getCustomMsg('diagOsCheckResult') || '';
-
                                 var approvedOs = [];
 
                                 if (_.isObject(data.approvedOs)) {
@@ -108,18 +113,62 @@ define([
                                     });
                                 }
 
-                                status.id = 'os_version';
-                                status.title = __('Operating system version');
-
-                                customMsg = customMsg
-                                    .replace(_placeHolders.CURRENT_OS, currentOs)
-                                    .replace(_placeHolders.APPROVED_OS, approvedOs.join(', '));
-                                diagnosticTool.addCustomFeedbackMsg(status, customMsg);
+                                status.customMsgRenderer = function(customMsg) {
+                                    return (customMsg || '')
+                                        .replace(_placeHolders.CURRENT_OS, currentOs)
+                                        .replace(_placeHolders.APPROVED_OS, approvedOs.join(', '));
+                                };
 
                                 done(status, summary, {compatible: data.success});
                             }
                         });
                     });
+            },
+
+            /**
+             * Gets the labels loaded for the tester
+             * @returns {Object}
+             */
+            get labels() {
+                return labels;
+            },
+
+            /**
+             * Builds the results summary
+             * @param {Object} results
+             * @param {Object} data
+             * @returns {Object}
+             */
+            getSummary: function getSummary(results, data) {
+                return {
+                    os: {
+                        message: labels.title,
+                        value: data.success ? labels.compatible : labels.notCompatible
+                    }
+                };
+            },
+
+            /**
+             * Gets the feedback status for the provided result value
+             * @param {Number} result
+             * @param {Object} data
+             * @returns {Object}
+             */
+            getFeedback: function getFeedback(result, data) {
+                var status = {
+                    percentage: result,
+                    quality: {},
+                    feedback: {
+                        message: data.success ? labels.success : labels.failure,
+                        threshold: 100,
+                        type: data.success ? 'success' : 'error'
+                    }
+                };
+
+                status.id = initConfig.id;
+                status.title =  labels.title;
+
+                return status;
             }
         };
     }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-5894

Due to a refactoring in `taoClientDiagnostic`, the testers brought by this extension were not working well and broke the diagnostics when activated.
Since the changes in the diagnostics tool introduced a flag to explicitly activate the testers, the issue was not visible on every install as those tools were deactivated (the flag `enabled` was not added).

The issue is occurring especially on some instances that has been manually updated, with enabling of those testers (`browserVersion` and `osVersion`). This is visible on some nightly instances.

This issue is blocking the tests of TAO-5894 since the nightly instance is impacted (cannot move it in "Ready for test" state).