### PR TITLE
[TAO-8093] ACT: Client Diagnostic Tool doesn't work.

### DIFF
--- a/install/RegisterClientDiagTester.php
+++ b/install/RegisterClientDiagTester.php
@@ -35,13 +35,13 @@ class RegisterClientDiagTester extends \common_ext_action_InstallAction
         $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoClientDiagnostic');
         $config = $extension->getConfig('clientDiag');
 
-        $config['testers']['browserVersion'] = [
+        $config['diagnostic']['testers']['browserVersion'] = [
             'enabled' => true,
             'level' => 1,
             'tester' => 'taoClientRestrict/diagnosticTools/browser/tester',
             'customMsgKey' => 'diagBrowserCheckResult'
         ];
-        $config['testers']['osVersion'] = [
+        $config['diagnostic']['testers']['osVersion'] = [
             'enabled' => true,
             'level' => 1,
             'tester' => 'taoClientRestrict/diagnosticTools/os/tester',

--- a/manifest.php
+++ b/manifest.php
@@ -32,12 +32,12 @@ return array(
     'label' => 'Client Restrictions',
     'description' => '',
     'license' => 'GPL-2.0',
-    'version' => '5.0.1',
+    'version' => '5.0.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'                 => '>=21.0.0',
         'taoDelivery'         => '>=11.0.0',
-        'taoClientDiagnostic' => '>=3.0.0',
+        'taoClientDiagnostic' => '>=6.0.1',
         'taoBackOffice'       => '>=3.0.0'
     ),
     'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#taoClientRestrictManager',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -124,6 +124,30 @@ class Updater extends common_ext_ExtensionUpdater {
         }
 
         $this->skip('4.0.1', '5.0.1');
+
+        if ($this->isVersion('5.0.1')) {
+            $extension = $this->getServiceManager()
+                ->get(\common_ext_ExtensionsManager::SERVICE_ID)
+                ->getExtensionById('taoClientDiagnostic');
+            $oldClientDiagConfig = $extension->getConfig('clientDiag');
+
+            $oldClientDiagConfig['diagnostic']['testers']['browserVersion'] = [
+                'enabled' => true,
+                'level' => 1,
+                'tester' => 'taoClientRestrict/diagnosticTools/browser/tester',
+                'customMsgKey' => 'diagBrowserCheckResult'
+            ];
+            $oldClientDiagConfig['diagnostic']['testers']['osVersion'] = [
+                'enabled' => true,
+                'level' => 1,
+                'tester' => 'taoClientRestrict/diagnosticTools/os/tester',
+                'customMsgKey' => 'diagOsCheckResult'
+            ];
+
+            $extension->setConfig('clientDiag', $oldClientDiagConfig);
+
+            $this->setVersion('5.0.2');
+        }
     }
 
 }


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TAO-8093
 
Fix issues related to update of taoClientDiagnostic extension config
 
#### Steps to reproduce  (for bugs)
To reproduce the issue please follow the steps described in the ticket
  
#### How to test
1.
- Install new ACT instance from develop branch
- Switch all affected extensions to PRs branches
- Update ACT instance
- Check that ltiClientDiag extension works without issues

2.
- Install new ACT instance from PRs branches
- Check that ltiClientDiag extension works without issues

  
#### Dependencies
   
Requires :
 - [ ] https://github.com/oat-sa/extension-tao-clientdiag/pull/234